### PR TITLE
Added support for Amazon Comprehend Medical

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ All components available in `src/components/`
     - `Polly.js`: Text to speech with standard or neural voice engine across all available languages
 - [Amazon Comprehend](https://ai-service-demos.go-aws.com/comprehend)
     - `Comprehend.js`: Sentiment, Entity, Key Phrase, and Syntax Token detection
+- [Amazon Comprehend Medical](https://ai-service-demos.go-aws.com/comprehend-medical)
+    - `ComprehendMedical.js`: Entity and Personal Health Information (PHI) detection
 - [Amazon Rekognition](https://ai-service-demos.go-aws.com/rekognition)
     - `Rekognition.js`: Object detection
 - [Amazon Translate](https://ai-service-demos.go-aws.com/translate)
@@ -35,13 +37,14 @@ To run/test locally:
 
 The services covered in this demo all have very generous free tiers. At a glance:
 
-| Service            | Description                    | Quantity                       | 
-|--------------------|--------------------------------|--------------------------------|
-| Amazon Translate   | Text-Text Translation          | 2 million characters/month     |
-| Amazon Polly       | Text to Speech                 | 5 million characters/month     |
-| Amazon Comprehend  | Natural Language Understanding | 5 million characters/API/month | 
-| Amazon Rekognition | Computer Vision                | 5k images/month                | 
-| Amazon Transcribe  | Audio to Text Transcription    | 60 minutes/month               |  
+| Service                   | Description                    | Quantity                         | 
+|---------------------------|--------------------------------|----------------------------------|
+| Amazon Translate          | Text-Text Translation          | 2 million characters/month       |
+| Amazon Polly              | Text to Speech                 | 5 million characters/month       |
+| Amazon Comprehend         | Natural Language Understanding | 5 million characters/API/month   | 
+| Amazon Comprehend Medical | Natural Language Understanding | 8.5 million characters/API/month |
+| Amazon Rekognition        | Computer Vision                | 5k images/month                  | 
+| Amazon Transcribe         | Audio to Text Transcription    | 60 minutes/month                 |  
 
 For the most up-to-date info on free tier status, check out [the live pricing page here](https://aws.amazon.com/free/).
 

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Polly from './components/Polly';
 import Transcribe from './components/Transcribe';
 import Main from './components/Main';
 import Comprehend from './components/Comprehend';
+import ComprehendMedical from './components/ComprehendMedical';
 import Rekognition from './components/Rekognition';
 import Translate from './components/Translate';
 //import NavBar from './utilities/navbar';
@@ -18,6 +19,7 @@ class App extends Component {
       <Route path='/polly' component={Polly}/>
       <Route path='/transcribe' component={Transcribe}/>
       <Route path='/comprehend' component={Comprehend}/>
+      <Route path='/comprehend-medical' component={ComprehendMedical}/>
       <Route path='/rekognition' component={Rekognition} />
       <Route path='/translate' component={Translate} />
     </Switch>

--- a/src/components/ComprehendMedical.js
+++ b/src/components/ComprehendMedical.js
@@ -1,0 +1,137 @@
+import React, {Component} from 'react';
+import NavBar from '../utilities/navbar';
+import Footer from '../utilities/footer';
+
+var AWS = require('aws-sdk');
+AWS.config.region = 'us-east-1'; 
+AWS.config.credentials = new AWS.CognitoIdentityCredentials({IdentityPoolId: 'us-east-1:1956382a-b3f6-472c-9a8d-3a246853c917'});
+
+class ComprehendMedical extends Component {
+  constructor(props){
+    super(props);
+    this.state = {
+        text: '',
+        resultEntities: '',
+        resultEntitiesMessage: '',
+        resultDetectPhiEntitiesMessage: '',
+        resultDetectPhiEntities: [],
+    }
+    this.onChangeText = this.onChangeText.bind(this);
+    this.sendTextToComprehendMedical = this.sendTextToComprehendMedical.bind(this);
+  }
+
+  onChangeText(e){
+    this.setState({text: e.target.value});
+  }
+
+  sendTextToComprehendMedical = () => {
+    var comprehendMedicalParams = {
+      Text: ""
+    };
+    comprehendMedicalParams.Text = this.state.text;
+    
+    // Initialize Comprehend Medical client
+    var comprehendMedical = new AWS.ComprehendMedical({apiVersion: '2018-10-30'});
+    let currentComponent = this;
+    
+    // Detect Entities
+    comprehendMedical.detectEntities(comprehendMedicalParams, function (err, data){
+      if (err) {
+        currentComponent.setState({resultEntitiesMessage: err.message});
+        currentComponent.setState({resultEntities: ""})
+        console.log(err)
+      }
+      else {
+        currentComponent.setState({resultEntitiesMessage: ">>> Entities analyzed!"})
+        currentComponent.setState({resultEntities: JSON.stringify(data.Entities)});
+      }
+      document.getElementById("chck1").checked = true;
+    });
+
+    // Detect PHI entities
+    comprehendMedical.detectPHI(comprehendMedicalParams, function (err, data){
+      if (err) {
+        currentComponent.setState({resultDetectPhiEntitiesMessage: err.message});
+        currentComponent.setState({resultDetectPhiEntities: ""});
+      }
+      else {
+        currentComponent.setState({resultDetectPhiEntitiesMessage: ">>> Detect PHI operation complete!"});
+        currentComponent.setState({resultDetectPhiEntities: JSON.stringify(data.Entities)});
+      }
+      document.getElementById("chck2").checked = true;
+    });
+  }
+
+  render() {
+    let entities, phiEntities, entitiesStatus, phiEntitiesStatus;
+    if(this.state.resultEntitiesMessage !== '' && this.state.resultDetectPhiEntitiesMessage != '') {
+      entities = <code>{this.state.resultEntities}</code>
+      phiEntities = <code>{this.state.resultDetectPhiEntities}</code>
+      entitiesStatus = <code>{this.state.resultEntitiesMessage}</code>
+      phiEntitiesStatus = <code>{this.state.resultDetectPhiEntitiesMessage}</code>
+    }
+    return (
+      <div className="App">
+        <NavBar/>
+        <div className="container">
+        <div className="content-wrap">
+        <div className="row text-left">
+          <h1>Amazon Comprehend Medical</h1>
+        </div>
+        <div class="titlebar"></div> 
+          <div className="row text-left">
+            <p><a href="https://aws.amazon.com/comprehend/medical/" target="_blank" rel="noopener noreferrer">Amazon Comprehend Medical</a> detects and returns useful information in unstructured clinical text such as physician's notes, discharge summaries, test results, and case notes. Amazon Comprehend Medical uses natural language processing (NLP) models to detect entities, which are textual references to medical information such as medical conditions, medications, or Protected Health Information (PHI).</p>
+            <p>In this example, we're going to show how easy it is to send text to <code>Amazon Comprehend Medical</code> to understand and extract health data from medical text, such as prescriptions, procedures, or diagnoses.</p>
+            <p>
+              <b>Methods:</b>
+              <br></br>
+              <code>sendTextToComprehendMedical()</code>: Send text to Comprehend Medical, returning all relevant results in the response body.<br></br>
+                <li><code><a href="https://docs.aws.amazon.com/comprehend-medical/latest/dev/textanalysis-entities.html" target="_blank" rel="noopener noreferrer">detectEntities()</a></code></li>
+                <li><code><a href="https://docs.aws.amazon.com/comprehend-medical/latest/dev/textanalysis-phi.html" target="_blank" rel="noopener noreferrer">detectPHI()</a></code></li>
+            </p>
+          </div>
+          <div className="row">
+            <div className="col-md-5 text-left">
+              <h4>Step 1: Insert Text</h4>
+              <form>
+                <div className="form-group">
+                  <textarea class="form-control" rows="5" value={this.state.text} onChange={this.onChangeText} placeholder="Enter the text for Comprehend to analyze!"/>
+                </div>
+                <button type="button" className="btn btn-info" onClick={this.sendTextToComprehendMedical}>Analyze text with Comprehend Medical</button>
+              </form>
+            </div>
+            <div className="col-md-7 text-left">
+              <h4>Results: </h4>
+              <div class="row">
+                <div class="col">
+                  <div class="tabs">
+                    <div class="tab">
+                      <input hidden type="checkbox" id="chck1"/>
+                      <label class="tab-label" htmlFor="chck1">Entities</label>
+                      <div class="tab-content">
+                        {entitiesStatus}
+                        {entities}
+                      </div>
+                    </div>
+                    <div class="tab">
+                      <input hidden type="checkbox" id="chck2"/>
+                      <label class="tab-label" htmlFor="chck2">PHI Entities</label>
+                      <div class="tab-content">
+                        {phiEntitiesStatus}
+                        {phiEntities}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <Footer/>
+        </div> 
+      </div>
+    </div>
+    );
+  }
+}
+
+export default ComprehendMedical;

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -76,6 +76,19 @@ class Main extends Component {
                             </div>
                             <div className="card">
                                 <div className="card-body">
+                                    <h5 className="card-title">Amazon Comprehend Medical</h5>
+                                    <div class="bar">
+                                        <div class="emptybar"></div>
+                                        <div class="filledbar"></div>
+                                    </div>
+                                    <p className="card-text">Amazon Comprehend Medical is a HIPAA-eligible natural language processing (NLP) service that uses machine learning that has been pre-trained to understand and extract health data from medical text, such as prescriptions, procedures, or diagnoses.</p>
+                                    <br></br>
+                                    <a href="/comprehend-medical" className="btn btn-info">Try Comprehend Medical</a>
+                                    <a href="https://docs.aws.amazon.com/comprehend-medical/latest/dev/comprehendmedical-welcome.html" target="_blank" rel="noopener noreferrer" className="btn btn-info">Docs</a>
+                                </div>
+                            </div>
+                            <div className="card">
+                                <div className="card-body">
                                     <h5 className="card-title">Amazon Rekognition</h5>
                                     <div class="bar">
                                         <div class="emptybar"></div>

--- a/src/utilities/navbar.js
+++ b/src/utilities/navbar.js
@@ -11,6 +11,7 @@ export default class NavBarHeader extends Component {
         <span><li><a href="/transcribe"class="item">Transcribe</a></li></span>
         <span><li><a href="/polly" class="item">Polly</a></li></span>
         <span><li><a href="/comprehend" class="item">Comprehend</a></li></span>
+        <span><li><a href="/comprehend-medical" class="item">Comprehend Medical</a></li></span>
         <span><li><a href="/rekognition" class="item">Rekognition</a></li></span>
         <span><li><a href="/translate" class="item">Translate</a></li></span>
     </div>


### PR DESCRIPTION
Added demo for [Amazon Comprehend Medical](https://aws.amazon.com/comprehend/medical/) - just needs permissions to make `comprehendmedical:*` calls.

![How it works](https://d1.awsstatic.com/product-marketing/comprehend/medical/product-page-diagram_Amazon-Comprehend-Medical_HIW.1602fc1fcaeac97995463e57721917750ee9707e.png)